### PR TITLE
Allow default emit from EventEmitter to be accessible for sync events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import {EventEmitter} from 'events';
 
 export class AsyncEventEmitter extends EventEmitter {
+	emitSync = EventEmitter.prototype.emit // Allow default emit to be accessible for the purposes of sync functions.
+
 	emit (type) {
 		var options = {
 			series: false,


### PR DESCRIPTION
Please check out my comments in 'Issues' to see why people might need the default synchronous `emit` to be accessible.