### PR TITLE
Fixes return values from synchronous callback functions not being passed to the promises resolved output.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ export class AsyncEventEmitter extends EventEmitter {
 
 			let callbacks = events[type];
 			if (!callbacks) {
-				return resolve(false);
+				return resolve();
 			}
 
 			// helper function to reuse as much code as possible
@@ -75,7 +75,7 @@ export class AsyncEventEmitter extends EventEmitter {
 					return cb;
 				}
 
-				return Promise.resolve(true);
+				return Promise.resolve(cb);
 			};
 
 			if (typeof callbacks === 'function') {


### PR DESCRIPTION
Fixes return values from synchronous callback functions not being passed to the promises resolved output. Also makes the resolved value when no callback functions are found be `undefined` to match.

Sample Code:
```js
const EventEmitter = require('events-async')

const testEmitter = new EventEmitter()

testEmitter.on('test1', () => {
  return 'a'
})

testEmitter.on('test1', async () => {
  return 'b'
})

testEmitter.emit('test1').then(result => console.log('test1', result))
testEmitter.emit('test2').then(result => console.log('test2', result))
```

Output before change:
```
test1 [ true, 'b' ]
test2 false
```
Output after change:
```
test1 [ 'a', 'b' ]
test2 undefined
```